### PR TITLE
Refactor testing

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 spring:
   config:
     activate:
-      on-profile: "rsocket"
+      on-profile: "rsocketws"
   graphql:
     rsocket:
       mapping: "graphql"
@@ -24,14 +24,11 @@ spring:
 spring:
   config:
     activate:
-      on-profile: "combined"
+      on-profile: "rsockettcp"
   graphql:
-    websocket:
-      path: "/graphql"
     rsocket:
       mapping: "graphql"
   rsocket:
     server:
-      mapping-path: "/graphql"
-      transport: "websocket"
+      port: 9191
 

--- a/src/main/resources/graphql-documents/project.graphql
+++ b/src/main/resources/graphql-documents/project.graphql
@@ -1,0 +1,5 @@
+{
+    project(slug:"spring-boot") {
+        name
+    }
+}

--- a/src/test/java/com/example/graphqlrsocket/GraphQlCombinedTests.java
+++ b/src/test/java/com/example/graphqlrsocket/GraphQlCombinedTests.java
@@ -1,7 +1,0 @@
-package com.example.graphqlrsocket;
-
-import org.springframework.test.context.ActiveProfiles;
-
-@ActiveProfiles("combined")
-public class GraphQlCombinedTests extends GraphQlRandomPortTests {
-}

--- a/src/test/java/com/example/graphqlrsocket/GraphQlRSocketTcpTests.java
+++ b/src/test/java/com/example/graphqlrsocket/GraphQlRSocketTcpTests.java
@@ -1,30 +1,26 @@
 package com.example.graphqlrsocket;
 
+import io.rsocket.transport.netty.client.TcpClientTransport;
+import io.rsocket.transport.netty.client.WebsocketClientTransport;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.graphql.client.WebSocketGraphQlClient;
+import org.springframework.graphql.client.RSocketGraphQlClient;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
-import org.springframework.web.reactive.socket.client.WebSocketClient;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@ActiveProfiles("websocket")
+@ActiveProfiles("rsockettcp")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-public class GraphQlWebSocketTests {
-
-	@LocalServerPort
-	private int localPort;
+public class GraphQlRSocketTcpTests {
 
 	@Test
-	void getProjectUsingWebSocket() {
-		WebSocketClient webClient = new ReactorNettyWebSocketClient();
-		WebSocketGraphQlClient graphQlClient = WebSocketGraphQlClient
-				.builder("http://localhost:" + localPort + "/graphql", webClient).build();
+	void getProjectUsingRSocket() {
+		TcpClientTransport transport = TcpClientTransport.create(9191);
+		RSocketGraphQlClient graphQlClient = RSocketGraphQlClient.builder().clientTransport(transport).build();
 		Mono<String> projectName = graphQlClient.documentName("project").retrieve("project.name").toEntity(String.class);
 		StepVerifier.create(projectName).expectNext("Spring Boot").expectComplete().verify();
 	}

--- a/src/test/java/com/example/graphqlrsocket/GraphQlRSocketTests.java
+++ b/src/test/java/com/example/graphqlrsocket/GraphQlRSocketTests.java
@@ -1,7 +1,0 @@
-package com.example.graphqlrsocket;
-
-import org.springframework.test.context.ActiveProfiles;
-
-@ActiveProfiles("rsocket")
-public class GraphQlRSocketTests extends GraphQlRandomPortTests {
-}

--- a/src/test/java/com/example/graphqlrsocket/GraphQlRSocketWsTests.java
+++ b/src/test/java/com/example/graphqlrsocket/GraphQlRSocketWsTests.java
@@ -10,42 +10,23 @@ import reactor.test.StepVerifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.graphql.client.RSocketGraphQlClient;
-import org.springframework.graphql.client.WebSocketGraphQlClient;
-import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
-import org.springframework.web.reactive.socket.client.WebSocketClient;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
+@ActiveProfiles("rsocketws")
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-abstract class GraphQlRandomPortTests {
-
-	private static final String DOCUMENT = """
-			{
-			  project(slug:"spring-boot") {
-				name
-			  }
-			}
-			""";
+public class GraphQlRSocketWsTests {
 
 	@LocalServerPort
 	private int localPort;
-
-	@Test
-	void getProjectUsingWebSocket() {
-		WebSocketClient webClient = new ReactorNettyWebSocketClient();
-		WebSocketGraphQlClient graphQlClient = WebSocketGraphQlClient
-				.builder("http://localhost:" + localPort + "/graphql", webClient).build();
-		Mono<String> projectName = graphQlClient.document(DOCUMENT).retrieve("project.name").toEntity(String.class);
-		StepVerifier.create(projectName).expectNext("Spring Boot").expectComplete().verify();
-	}
 
 	@Test
 	void getProjectUsingRSocket() {
 		URI uri = URI.create("http://localhost:" + localPort + "/graphql");
 		WebsocketClientTransport transport = WebsocketClientTransport.create(uri);
 		RSocketGraphQlClient graphQlClient = RSocketGraphQlClient.builder().clientTransport(transport).build();
-		Mono<String> projectName = graphQlClient.document(DOCUMENT).retrieve("project.name").toEntity(String.class);
+		Mono<String> projectName = graphQlClient.documentName("project").retrieve("project.name").toEntity(String.class);
 		StepVerifier.create(projectName).expectNext("Spring Boot").expectComplete().verify();
 	}
-
 }


### PR DESCRIPTION
I don't think we can enable both GraphQL over WebSocket and GraphQL over
RSocket (which itself uses WebSocket) as this causes a conflict: both
try to handle websocket connection upgrades on the same URL.

I've tried instead to produce an arrangement where we test RSocket over
both TCP and WebSocket.
